### PR TITLE
add `@inubekit/foundations` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,10 @@
     "version": "rm -rf dist && npm run build",
     "postversion": "git push --follow-tags && npm run auto release"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@inubekit/foundations": "^1.1.2"
+  },
   "peerDependencies": {
-    "@inubekit/foundations": "^1.1.2",
     "react-icons": "^5.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
The dependencies of the distributable are adjusted, preventing the distributable from containing code that does not strictly belong to the `<Icon/>` component.