### PR TITLE
Refactor appearance prop so it isn't of type string, but type "primary" | "warning" | ...

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@inubekit/icon",
       "version": "1.2.0",
       "dependencies": {
-        "@inubekit/foundations": "^2.2.1"
+        "@inubekit/foundations": "^2.6.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^18.4.4",
@@ -3394,9 +3394,9 @@
       "dev": true
     },
     "node_modules/@inubekit/foundations": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@inubekit/foundations/-/foundations-2.2.1.tgz",
-      "integrity": "sha512-RIcZjLEIy9uJML4680q+KsO3yK/b8c2VkIosC4eCVomanvuPga/zLpneEXvWcXAx5kfiZz/pAjZxoOuRQ0PN9A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inubekit/foundations/-/foundations-2.6.0.tgz",
+      "integrity": "sha512-+TtypifdVB+5z/ILYRrYj0kwUavcKsMjEcVxALRYcXUCXeWUbc7JeUJkKo6HbhZ41WV2xM+Obe5j52k/qLXWzQ==",
       "peerDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "auto": "auto",
     "changelog": "npm run auto changelog",
     "version": "rm -rf dist && npm run build",
-    "postversion": "git push --follow-tags && npm run auto release"
+    "release": "git push --follow-tags && npm run auto release"
   },
   "peerDependencies": {
     "react": "^18.2.0",
@@ -73,6 +73,6 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "@inubekit/foundations": "^2.2.1"
+    "@inubekit/foundations": "^2.6.0"
   }
 }

--- a/src/Icon/Icon.stories.tsx
+++ b/src/Icon/Icon.stories.tsx
@@ -1,7 +1,7 @@
 import { MdAdb } from "react-icons/md";
 import { action } from "@storybook/addon-actions";
 
-import { Icon, IIconProps } from ".";
+import { Icon, IIcon } from ".";
 
 import { props, parameters } from "./props";
 
@@ -12,8 +12,7 @@ const story = {
   argTypes: props,
 };
 
-export const Default = (args: IIconProps) => <Icon {...args} />;
-
+const Default = (args: IIcon) => <Icon {...args} />;
 Default.args = {
   appearance: "primary",
   icon: <MdAdb />,
@@ -27,4 +26,5 @@ Default.args = {
   onClick: action("onClick"),
 };
 
+export { Default };
 export default story;

--- a/src/Icon/index.tsx
+++ b/src/Icon/index.tsx
@@ -1,7 +1,7 @@
 import { StyledIcon } from "./styles";
 import { Spacing, Variant, Shape, Appearance } from "./props";
 
-export interface IIconProps {
+interface IIcon {
   appearance: Appearance;
   cursorHover?: boolean;
   parentHover?: boolean;
@@ -14,7 +14,7 @@ export interface IIconProps {
   onClick?: () => void;
 }
 
-export const Icon = (props: IIconProps) => {
+const Icon = (props: IIcon) => {
   const {
     appearance,
     cursorHover,
@@ -44,3 +44,6 @@ export const Icon = (props: IIconProps) => {
     </StyledIcon>
   );
 };
+
+export { Icon };
+export type { IIcon };

--- a/src/Icon/props.ts
+++ b/src/Icon/props.ts
@@ -1,19 +1,26 @@
-import { inube } from "@inubekit/foundations";
+const shapes = ["circle", "rectangle"] as const;
+type Shape = (typeof shapes)[number];
 
-export const shapes = ["circle", "rectangle"] as const;
-export type Shape = (typeof shapes)[number];
+const spacings = ["none", "compact", "wide"] as const;
+type Spacing = (typeof spacings)[number];
 
-export const spacings = ["none", "compact", "wide"] as const;
-export type Spacing = (typeof spacings)[number];
+const variants = ["filled", "outlined", "none"] as const;
+type Variant = (typeof variants)[number];
 
-export const variants = ["filled", "outlined", "none"] as const;
-export type Variant = (typeof variants)[number];
+const appearances = [
+  "primary",
+  "success",
+  "warning",
+  "danger",
+  "help",
+  "dark",
+  "gray",
+  "light",
+] as const;
 
-const appearances = Object.keys(inube.icon);
+type Appearance = (typeof appearances)[number];
 
-export type Appearance = (typeof appearances)[number];
-
-export const parameters = {
+const parameters = {
   docs: {
     description: {
       component: "Icons used to communicate actions and decisions graphically",
@@ -21,7 +28,7 @@ export const parameters = {
   },
 };
 
-export const props = {
+const props = {
   appearance: {
     options: appearances,
     control: { type: "select" },
@@ -100,3 +107,6 @@ export const props = {
     description: "size of the icon in pixels",
   },
 };
+
+export { parameters, props, shapes, spacings, variants };
+export type { Appearance, Shape, Spacing, Variant };

--- a/src/Icon/styles.js
+++ b/src/Icon/styles.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 import { inube } from "@inubekit/foundations";
 
-export const StyledIcon = styled.figure`
+const StyledIcon = styled.figure`
   display: inline-block;
   padding: 0px;
   margin: 0px;
@@ -133,3 +133,4 @@ export const StyledIcon = styled.figure`
     }};
   }
 `;
+export { StyledIcon };


### PR DESCRIPTION
This pull request introduces a significant refactor of the appearance prop within a key UI component of our application. Previously typed as a generic string, the appearance prop has now been updated to a more explicit union type, specifically "primary" | "warning" | ..., among other predefined appearance options. This change aims to improve type safety, developer experience, and the overall maintainability of the component by clearly defining the acceptable appearance values.