### PR TITLE
Adjustment: Include 'None' as Default for Variant

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@inubekit/foundations": "^2.6.1"
+    "@inubekit/foundations": "^5.0.0"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/src/Icon/index.tsx
+++ b/src/Icon/index.tsx
@@ -27,7 +27,7 @@ const Icon = (props: IIcon) => {
     icon,
     disabled,
     spacing,
-    variant,
+    variant = "none",
     shape,
     size,
     onClick,


### PR DESCRIPTION
This pull request makes adjustments to ensure that 'None' is included as the default value for the variant property.