### PR TITLE
Move icon tokens from foundations to component

### DIFF
--- a/src/Icon/Tokens/tokens.ts
+++ b/src/Icon/Tokens/tokens.ts
@@ -1,0 +1,190 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  primary: {
+    content: {
+      color: {
+        regular: inube.palette.blue.B400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.blue.B300,
+      },
+    },
+    background: {
+      color: {
+        regular: inube.palette.blue.B400,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.blue.B300,
+      },
+    },
+    contrast: {
+      color: {
+        regular: inube.palette.neutral.N10,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N10,
+      },
+    },
+  },
+  success: {
+    content: {
+      color: {
+        regular: inube.palette.green.G400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.green.G300,
+      },
+    },
+    background: {
+      color: {
+        regular: inube.palette.green.G400,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.green.G300,
+      },
+    },
+    contrast: {
+      color: {
+        regular: inube.palette.neutral.N10,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N10,
+      },
+    },
+  },
+  warning: {
+    content: {
+      color: {
+        regular: inube.palette.yellow.Y400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.yellow.Y300,
+      },
+    },
+    background: {
+      color: {
+        regular: inube.palette.yellow.Y400,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.yellow.Y300,
+      },
+    },
+    contrast: {
+      color: {
+        regular: inube.palette.neutral.N10,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N10,
+      },
+    },
+  },
+  danger: {
+    content: {
+      color: {
+        regular: inube.palette.red.R400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.red.R300,
+      },
+    },
+    background: {
+      color: {
+        regular: inube.palette.red.R400,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.red.R300,
+      },
+    },
+    contrast: {
+      color: {
+        regular: inube.palette.neutral.N10,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N10,
+      },
+    },
+  },
+  help: {
+    content: {
+      color: {
+        regular: inube.palette.purple.P400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.purple.P300,
+      },
+    },
+    background: {
+      color: {
+        regular: inube.palette.purple.P400,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.purple.P300,
+      },
+    },
+    contrast: {
+      color: {
+        regular: inube.palette.neutral.N10,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N10,
+      },
+    },
+  },
+  dark: {
+    content: {
+      color: {
+        regular: inube.palette.neutral.N900,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N500,
+      },
+    },
+    background: {
+      color: {
+        regular: inube.palette.neutral.N900,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.neutral.N500,
+      },
+    },
+    contrast: {
+      color: {
+        regular: inube.palette.neutral.N10,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N10,
+      },
+    },
+  },
+  gray: {
+    content: {
+      color: {
+        regular: inube.palette.neutral.N300,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N100,
+      },
+    },
+    background: {
+      color: {
+        regular: inube.palette.neutral.N300,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.neutral.N100,
+      },
+    },
+    contrast: {
+      color: {
+        regular: inube.palette.neutral.N900,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N900,
+      },
+    },
+  },
+  light: {
+    content: {
+      color: {
+        regular: inube.palette.neutral.N10,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N0,
+      },
+    },
+    background: {
+      color: {
+        regular: inube.palette.neutral.N10,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.neutral.N0,
+      },
+    },
+    contrast: {
+      color: {
+        regular: inube.palette.neutral.N900,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N900,
+      },
+    },
+  },
+};
+
+export { tokens };

--- a/src/Icon/styles.js
+++ b/src/Icon/styles.js
@@ -1,6 +1,5 @@
 import styled from "styled-components";
-
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const StyledIcon = styled.figure`
   display: inline-block;
@@ -22,22 +21,22 @@ const StyledIcon = styled.figure`
       if (disabled)
         return (
           theme?.icon?.[$appearance]?.contrast?.color?.disabled ||
-          inube.icon[$appearance].contrast.color.disabled
+          tokens[$appearance].contrast.color.disabled
         );
       if ($variant !== "filled") {
         if ($parentHover)
           return (
             theme?.icon?.[$appearance]?.content?.color?.hover ||
-            inube.icon[$appearance].content.color.hover
+            tokens[$appearance].content.color.hover
           );
         return (
           theme?.icon?.[$appearance]?.content?.color?.regular ||
-          inube.icon[$appearance].content.color.regular
+          tokens[$appearance].content.color.regular
         );
       }
       return (
         theme?.icon?.[$appearance]?.contrast?.color?.regular ||
-        inube.icon[$appearance].contrast.color.regular
+        tokens[$appearance].contrast.color.regular
       );
     }};
 
@@ -52,16 +51,16 @@ const StyledIcon = styled.figure`
         if (disabled)
           return (
             theme?.icon?.[$appearance]?.background?.color?.disabled ||
-            inube.icon[$appearance].background.color.disabled
+            tokens[$appearance].background.color.disabled
           );
         if ($parentHover)
           return (
             theme?.icon?.[$appearance]?.background?.color?.hover ||
-            inube.icon[$appearance].background.color.hover
+            tokens[$appearance].background.color.hover
           );
         return (
           theme?.icon?.[$appearance]?.background?.color?.regular ||
-          inube.icon[$appearance].background.color.regular
+          tokens[$appearance].background.color.regular
         );
       }
     }};
@@ -80,16 +79,16 @@ const StyledIcon = styled.figure`
       if (disabled)
         return (
           theme?.icon?.[$appearance]?.content?.color?.disabled ||
-          inube.icon[$appearance].content.color.disabled
+          tokens[$appearance].content.color.disabled
         );
       if ($parentHover && $variant !== "filled")
         return (
           theme?.icon?.[$appearance]?.content?.color?.hover ||
-          inube.icon[$appearance].content.color.hover
+          tokens[$appearance].content.color.hover
         );
       return (
         theme?.icon?.[$appearance]?.content?.color?.regular ||
-        inube.icon[$appearance].content.color.regular
+        tokens[$appearance].content.color.regular
       );
     }};
   }
@@ -109,7 +108,7 @@ const StyledIcon = styled.figure`
       if (!disabled && $cursorHover && $variant !== "filled")
         return (
           theme?.icon?.[$appearance]?.content?.color?.hover ||
-          inube.icon[$appearance].content.color.hover
+          tokens[$appearance].content.color.hover
         );
     }};
 
@@ -117,7 +116,7 @@ const StyledIcon = styled.figure`
       if (!disabled && $cursorHover && $variant !== "filled")
         return (
           theme?.icon?.[$appearance]?.content?.color?.hover ||
-          inube.icon[$appearance].content.color.hover
+          tokens[$appearance].content.color.hover
         );
     }};
 
@@ -131,7 +130,7 @@ const StyledIcon = styled.figure`
       if (!disabled && $variant === "filled" && $cursorHover)
         return (
           theme?.icon?.[$appearance]?.background?.color?.hover ||
-          inube.icon[$appearance].background.color.hover
+          tokens[$appearance].background.color.hover
         );
     }};
   }


### PR DESCRIPTION
This PR relocates the icon tokens from the foundations folder to the component folder, updating all necessary imports to reflect the new structure and ensuring that components reference the correct token paths. This improves the organization, maintainability, and clarity of the codebase.